### PR TITLE
Add CODEOWNERS file to define repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @irvanrizkin @Aldi-H


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns ownership of all files to `@irvanrizkin` and `@Aldi-H`.