### PR TITLE
feat: add Tutorial sections with data table to dashboard

### DIFF
--- a/src/app/(dashboard)/tutorial/components/lead-capture-columns.tsx
+++ b/src/app/(dashboard)/tutorial/components/lead-capture-columns.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import Link from "next/link";
+import { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+export type Tutorials = {
+  id: string;
+  title: string;
+  subtitle: string;
+  action: ReactNode;
+};
+
+export const TutorialsColums: ColumnDef<Tutorials>[] = [
+  {
+    accessorKey: "title",
+    header: "Title",
+    cell: ({ row }) => (
+      <span className="font-medium">{row.getValue("title")}</span>
+    ),
+  },
+  {
+    accessorKey: "subtitle",
+    header: "Subtitle",
+  },
+  {
+    accessorKey: "action",
+    header: "Actions",
+    cell: ({ row }) => (
+      <Button variant="outline">
+        <Link href="#">
+          {row.getValue("action")}
+          <span className="sr-only">Edit Blog</span>
+        </Link>
+      </Button>
+    ),
+  },
+];

--- a/src/app/(dashboard)/tutorial/page.tsx
+++ b/src/app/(dashboard)/tutorial/page.tsx
@@ -1,0 +1,41 @@
+import { SquarePen } from "lucide-react";
+
+import DataTable from "@/components/data-table/data-table";
+
+import { TutorialsColums } from "./components/lead-capture-columns";
+
+const LeadCapture = () => {
+  return (
+    <div className="min-h-screen flex flex-col gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+            Tutorials
+          </h1>
+          <p className="text-muted-foreground">Manage Tutorials</p>
+        </div>
+      </div>
+
+      <div>
+        <DataTable columns={TutorialsColums} data={tutorialsData} />
+      </div>
+    </div>
+  );
+};
+
+export default LeadCapture;
+
+const tutorialsData = [
+  {
+    id: "3e1d4553-b801-40c1-a97b-52a4e649a324",
+    title: "Understanding React Components",
+    subtitle: "A Deep Dive into Functional and Class Components",
+    action: <SquarePen className="h-4 w-4" />,
+  },
+  {
+    id: "3e1d4553-b801-40c1-a97b-52a4e649a324",
+    title: "Understanding React Components",
+    subtitle: "A Deep Dive into Functional and Class Components",
+    action: <SquarePen className="h-4 w-4" />,
+  },
+];

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import {
   BarChart3,
   BookUser,
+  FileQuestion,
   HelpCircle,
   LayoutDashboard,
   LogOut,
@@ -154,6 +155,7 @@ const navItems = [
   { name: "Analytics", href: "/analytics", icon: BarChart3 },
   { name: "Lead Capture", href: "/lead-capture", icon: BookUser },
   { name: "Blogs", href: "/blogs", icon: Newspaper },
+  { name: "Tutorial", href: "/tutorial", icon: FileQuestion },
 ];
 
 const footerItems = [


### PR DESCRIPTION
This pull request introduces a new "Tutorial" dashboard page, complete with a data table for managing tutorials, and updates the sidebar navigation to include this new section. The main changes involve setting up the table columns and data for tutorials, implementing the page layout, and ensuring the new section is accessible from the sidebar.

**Dashboard Tutorials Feature:**

* Added a new `Tutorial` page at `/tutorial` that displays a list of tutorials in a data table, including columns for title, subtitle, and actions, with sample data and action icons. (`src/app/(dashboard)/tutorial/page.tsx`)
* Defined the table column configuration and type for tutorials, including custom cell rendering for actions, in `lead-capture-columns.tsx`. (`src/app/(dashboard)/tutorial/components/lead-capture-columns.tsx`)

**Sidebar Navigation:**

* Added a new navigation item for "Tutorial" with the `FileQuestion` icon, linking to the new tutorial dashboard page. (`src/components/sidebar/sidebar.tsx`) [[1]](diffhunk://#diff-cbfc15c04256532d187f36fe32f0d7f9bdef773bd2a0cc598956dc31faa309d8R7) [[2]](diffhunk://#diff-cbfc15c04256532d187f36fe32f0d7f9bdef773bd2a0cc598956dc31faa309d8R158)