### PR TITLE
[FEAT] Auth Guard, Hide Sidebar Nav Items

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -12,16 +12,36 @@ export default async function DashboardLayout({
   children: React.ReactNode;
 }) {
   const supabase = await createClient();
-  const { error } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (error) {
+  if (!user) {
     redirect("/login");
   }
+
+  let role = "user";
+  let permissions = [];
+
+  const { data: userTable } = await supabase
+    .from("users")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+
+  role = userTable?.role || "user";
+
+  const { data: permissionTable } = await supabase
+    .from("user_permissions")
+    .select("permission")
+    .eq("user_id", user.id);
+
+  permissions = permissionTable?.map((item) => item.permission) || [];
 
   return (
     <SidebarProvider>
       <div className="min-h-screen bg-background">
-        <Sidebar />
+        <Sidebar role={role} permissions={permissions} />
         <div className="lg:pl-72">
           <Header />
           <main className="p-4 md:p-6 lg:p-8">{children}</main>

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -2,17 +2,11 @@
 
 import { cn } from "@/lib/utils";
 import {
-  BarChart3,
   BookUser,
-  FileQuestion,
-  HelpCircle,
   LayoutDashboard,
-  LogOut,
   Menu,
   Newspaper,
-  Settings,
   Users,
-  Wallet,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -21,9 +15,21 @@ import { Button } from "@/components/ui/button";
 
 import { useSidebar } from "./sidebar-provider";
 
-export function Sidebar() {
+interface SidebarProps {
+  role: string;
+  permissions: string[];
+}
+
+export function Sidebar({ role, permissions }: SidebarProps) {
   const pathname = usePathname();
   const { isOpen, toggle } = useSidebar();
+
+  const filteredNavItems =
+    role === "admin"
+      ? navItems
+      : navItems.filter(
+          (item) => !item.permissions || permissions.includes(item.permissions),
+        );
 
   return (
     <>
@@ -57,7 +63,7 @@ export function Sidebar() {
         <div className="flex flex-col h-[calc(100vh-3.5rem)]">
           <div className="flex-1 overflow-auto py-2">
             <nav className="grid gap-1 px-2">
-              {navItems.map((item, index) => (
+              {filteredNavItems.map((item, index) => (
                 <Link
                   key={index}
                   href={item.href}
@@ -79,69 +85,6 @@ export function Sidebar() {
               ))}
             </nav>
           </div>
-          <div className="border-t p-2">
-            <nav className="grid gap-1">
-              {footerItems.map((item, index) => (
-                <div key={index}>
-                  {item.subItems ? (
-                    <div className="space-y-1">
-                      <Link
-                        href={item.href}
-                        className={cn(
-                          "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
-                          pathname === item.href
-                            ? "bg-accent text-accent-foreground"
-                            : "text-muted-foreground",
-                        )}
-                      >
-                        <item.icon className="h-5 w-5" />
-                        <span>{item.name}</span>
-                      </Link>
-                      <div className="pl-4 space-y-1">
-                        {item.subItems.map((subItem, subIndex) => (
-                          <Link
-                            key={subIndex}
-                            href={subItem.href}
-                            className={cn(
-                              "flex items-center gap-3 rounded-md px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground",
-                              pathname === subItem.href
-                                ? "bg-accent text-accent-foreground"
-                                : "text-muted-foreground",
-                            )}
-                          >
-                            <span>{subItem.name}</span>
-                            {subItem.description && (
-                              <span className="ml-auto text-xs text-muted-foreground">
-                                {subItem.description}
-                              </span>
-                            )}
-                          </Link>
-                        ))}
-                      </div>
-                    </div>
-                  ) : (
-                    <Link
-                      href={item.href}
-                      className={cn(
-                        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
-                        pathname === item.href
-                          ? "bg-accent text-accent-foreground"
-                          : "text-muted-foreground",
-                      )}
-                    >
-                      <item.icon className="h-5 w-5" />
-                      <span>{item.name}</span>
-                      {item.description && (
-                        <span className="ml-auto text-xs text-muted-foreground">
-                          {item.description}
-                        </span>
-                      )}
-                    </Link>
-                  )}
-                </div>
-              ))}
-            </nav>
-          </div>
         </div>
       </div>
     </>
@@ -151,46 +94,16 @@ export function Sidebar() {
 const navItems = [
   { name: "Dashboard", href: "/dashboard", icon: LayoutDashboard },
   { name: "Users", href: "/users", icon: Users, badge: "8" },
-  { name: "Transactions", href: "/transactions", icon: Wallet },
-  { name: "Analytics", href: "/analytics", icon: BarChart3 },
-  { name: "Lead Capture", href: "/lead-capture", icon: BookUser },
-  { name: "Blogs", href: "/blogs", icon: Newspaper },
-  { name: "Tutorial", href: "/tutorial", icon: FileQuestion },
-];
-
-const footerItems = [
   {
-    name: "Settings",
-    href: "/settings",
-    icon: Settings,
-    subItems: [
-      {
-        name: "Profile",
-        href: "/settings/profile",
-        description: "Update your details",
-      },
-      {
-        name: "Security",
-        href: "/settings/security",
-        description: "Manage your password",
-      },
-      {
-        name: "Communication",
-        href: "/settings/communication",
-        description: "Email and phone",
-      },
-      {
-        name: "Permissions",
-        href: "/settings/permissions",
-        description: "Access control",
-      },
-    ],
+    name: "Lead Capture",
+    href: "/lead-capture",
+    icon: BookUser,
+    permissions: "show-lead-capture",
   },
-  { name: "Help", href: "/help", icon: HelpCircle, description: "Get support" },
   {
-    name: "Logout",
-    href: "/logout",
-    icon: LogOut,
-    description: "Exit the app",
+    name: "Blogs",
+    href: "/blogs",
+    icon: Newspaper,
+    permissions: "create-blog",
   },
 ];


### PR DESCRIPTION
This pull request refactors the dashboard layout and sidebar to support role-based navigation and permissions. The main improvements include fetching user roles and permissions from the database, filtering sidebar navigation items based on these permissions, and simplifying the sidebar structure by removing the footer section.

**Role and permissions support:**

* The `DashboardLayout` in `layout.tsx` now fetches the user's role and permissions from the `users` and `user_permissions` tables, passing them to the `Sidebar` component.
* The `Sidebar` component's props are updated to accept `role` and `permissions`, and navigation items are filtered so that non-admin users only see items for which they have permissions. [[1]](diffhunk://#diff-cbfc15c04256532d187f36fe32f0d7f9bdef773bd2a0cc598956dc31faa309d8L24-R33) [[2]](diffhunk://#diff-cbfc15c04256532d187f36fe32f0d7f9bdef773bd2a0cc598956dc31faa309d8L60-R66)

**Sidebar structure and navigation:**

* The sidebar navigation items are refactored to include a `permissions` field, allowing for granular access control per item (e.g., "Lead Capture" and "Blogs" are now permission-gated).
* The footer navigation section (including settings, help, and logout) is removed from the sidebar, simplifying the UI.

**Code cleanup:**

* Unused icon imports are removed from the sidebar component for clarity and maintainability.